### PR TITLE
feat: integrate external RAG API for MBS item suggestions

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -19,6 +19,26 @@ export interface SuggestCandidate {
   short_explain?: string;
 }
 
+// RAG API types
+export interface RagRequest {
+  query: string;
+  top?: number;
+}
+
+export interface RagResult {
+  itemNum?: string;
+  itemNums?: string[];
+  title: string;
+  match_reason: string;
+  match_score: number;
+  fee: string;
+  benefit: string;
+}
+
+export interface RagResponse {
+  results: RagResult[];
+}
+
 export interface Signals {
   duration: number;
   mode: string;


### PR DESCRIPTION
- Add RAG API types (RagRequest, RagResponse, RagResult) to shared package
- Update frontend to call external RAG API at bedrock-rag-api.onrender.com
- Implement conversion from RAG response format to internal SuggestResponse format
- Update UI to show RAG integration status instead of Day-1 prototype message
- Add support for both single itemNum and multiple itemNums in RAG results
- Include fee and benefit information in feature hits
- Update API endpoint display to show /rag/query instead of /api/suggest